### PR TITLE
Configuration service is exposed to IOTAs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,3 +7,4 @@
 - Add: NGSIv2 support for Expression Translation, Attribute Alias and Event plugins, through configuration (#527)
 - Add: NGSIv2 support for Bidirectionality plugin (#527)
 - Add: NGSIv2 support for Multientity plugin (#527)
+- Add: Configuration service is exposed as part of the module.

--- a/lib/fiware-iotagent-lib.js
+++ b/lib/fiware-iotagent-lib.js
@@ -240,3 +240,4 @@ exports.errors = errors;
 exports.constants = constants;
 
 exports.logModule = logger;
+exports.configModule = config;


### PR DESCRIPTION
Following the comments of https://github.com/telefonicaid/lightweightm2m-iotagent/pull/111#pullrequestreview-89355608, configuration service is exposed so that IOTAs can call to functions like checkNgsi2.